### PR TITLE
Corrected dropdowns background colors

### DIFF
--- a/snowflake minima white aqua.css
+++ b/snowflake minima white aqua.css
@@ -13,6 +13,7 @@ The creators of the themes used are Diamant (@diamantlefou), Berter (@BerterTheB
 .column-head-title {color:blue!important;}
 .column-head-title + .txt-sub-antialiased {color:darkblue!important;}
 .prf-card-inner strong.fullname {color:white!important;}
+.tweet-action + .dropdown-menu {background-color: white;}
 /* End of @Shookaite's fix */
 
 /* Loading Screen */


### PR DESCRIPTION
The dropdown for tweet actions ("Retweet from account" / "Fav from account", etc) had a black background instead of a white one